### PR TITLE
Fix Drag/Release Behavior in GUI and Photo Dome

### DIFF
--- a/packages/dev/gui/src/2D/advancedDynamicTexture.ts
+++ b/packages/dev/gui/src/2D/advancedDynamicTexture.ts
@@ -886,6 +886,9 @@ export class AdvancedDynamicTexture extends DynamicTexture {
         const tempViewport = new Viewport(0, 0, 0, 0);
 
         this._prePointerObserver = scene.onPrePointerObservable.add((pi) => {
+            if (scene.isPointerCaptured(pi.event.pointerId) && pi.type === PointerEventTypes.POINTERUP) {
+                return;
+            }
             if (
                 pi.type !== PointerEventTypes.POINTERMOVE &&
                 pi.type !== PointerEventTypes.POINTERUP &&


### PR DESCRIPTION
Fix to allow mouse release to propagate to scene to allow for release of camera observers. See: https://forum.babylonjs.com/t/ispointerblocker-improvement/31152/10?u=stevendelapena